### PR TITLE
CPython embedding and iOS bundle script

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 
 # --- Settings ---
 
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "settings.json")
+_data_dir = os.environ.get("PYXUS_DATA_DIR", os.path.dirname(__file__))
+SETTINGS_PATH = os.path.join(_data_dir, "settings.json")
 
 
 def load_settings() -> dict:
@@ -1184,7 +1185,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
 # --- Static files (production) ---
 
-frontend_dist = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
+frontend_dist = os.environ.get("PYXUS_FRONTEND_DIR", os.path.join(os.path.dirname(__file__), "..", "frontend", "dist"))
 if os.path.isdir(frontend_dist):
     app.mount("/assets", StaticFiles(directory=os.path.join(frontend_dist, "assets")), name="assets")
 

--- a/ios/pyxios/pyxios/Python/PythonRunner.swift
+++ b/ios/pyxios/pyxios/Python/PythonRunner.swift
@@ -3,8 +3,7 @@
 //  pyxios
 //
 //  Embeds CPython via python-apple-support and starts the FastAPI/uvicorn backend.
-//  For now this is a stub that will be completed once python-apple-support is integrated.
-//  In development mode, it can connect to an external backend instead.
+//  In development mode, it polls an external backend instead.
 //
 
 import Foundation
@@ -24,17 +23,79 @@ final class PythonRunner: Sendable {
     }
 
     /// Start the Python backend.
-    /// In development: polls an external backend until it responds.
-    /// In production: will embed CPython and boot uvicorn in-process.
+    /// Tries embedded CPython first; falls back to polling an external backend.
     func start() async {
-        // --- Phase 1: Development mode ---
-        // Connect to an external backend running on the Mac (via network).
-        // The iOS simulator shares the host network, so localhost works.
-        // On a real device, you'd need the Mac's IP or use Bonjour discovery.
+        let bundle = Bundle.main
+        let resourcePath = bundle.resourcePath ?? ""
 
+        // Check if we have bundled Python resources (production build)
+        let hasBundledBackend = FileManager.default.fileExists(
+            atPath: resourcePath + "/backend/main.py"
+        )
+
+        if hasBundledBackend {
+            await startEmbedded(resourcePath: resourcePath)
+        } else {
+            await pollExternalBackend()
+        }
+    }
+
+    // MARK: - Embedded CPython
+
+    private func startEmbedded(resourcePath: String) async {
+        statusMessage = "Starting Python…"
+
+        // Run CPython initialization + uvicorn on a background queue
+        // so it doesn't block the main/actor thread.
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.initializePython(resourcePath: resourcePath)
+            self.runBootstrap(resourcePath: resourcePath)
+        }
+
+        // Poll /health until uvicorn is serving
+        await pollHealth()
+    }
+
+    private func initializePython(resourcePath: String) {
+        let pythonHome = resourcePath + "/python"
+        let sitePackages = resourcePath + "/site-packages"
+        let backendDir = resourcePath + "/backend"
+        let frontendDir = resourcePath + "/frontend-dist"
+
+        // Environment variables consumed by main.py / bootstrap.py
+        setenv("PYTHONHOME", pythonHome, 1)
+        setenv("PYTHONPATH", "\(sitePackages):\(backendDir)", 1)
+        setenv("PYTHONDONTWRITEBYTECODE", "1", 1)
+        setenv("PYXUS_DATA_DIR", backendDir, 1)
+        setenv("PYXUS_FRONTEND_DIR", frontendDir, 1)
+
+        Py_Initialize()
+    }
+
+    private func runBootstrap(resourcePath: String) {
+        let bootstrapPath = resourcePath + "/backend/bootstrap.py"
+
+        // Read and execute bootstrap.py — this blocks (uvicorn.run is blocking)
+        guard let script = try? String(contentsOfFile: bootstrapPath, encoding: .utf8) else {
+            DispatchQueue.main.async {
+                self.statusMessage = "Failed to read bootstrap.py"
+            }
+            return
+        }
+
+        PyRun_SimpleString(script)
+    }
+
+    // MARK: - Development mode (external backend)
+
+    private func pollExternalBackend() async {
         statusMessage = "Connecting to backend…"
+        await pollHealth()
+    }
 
-        // Poll /health until the backend is up (max 30s)
+    // MARK: - Health polling
+
+    private func pollHealth() async {
         let healthURL = baseURL.appendingPathComponent("api/health")
         let startTime = Date()
         let timeout: TimeInterval = 30
@@ -53,19 +114,8 @@ final class PythonRunner: Sendable {
             try? await Task.sleep(for: .milliseconds(500))
         }
 
-        statusMessage = "Backend not reachable — start it manually"
+        statusMessage = "Backend not reachable"
         // Still mark as ready so the WebView can load (it'll show connection errors)
         isReady = true
     }
-
-    // MARK: - Embedded Python (Phase 2 — not yet implemented)
-    //
-    // When python-apple-support is integrated:
-    // 1. Set PYTHONHOME to the bundled Python.framework
-    // 2. Set PYTHONPATH to include the bundled backend/ directory
-    // 3. Call Py_Initialize()
-    // 4. Run bootstrap.py which starts uvicorn
-    // 5. Poll /health until ready
-    //
-    // func startEmbeddedPython() async { ... }
 }

--- a/ios/pyxios/pyxios/Python/bootstrap.py
+++ b/ios/pyxios/pyxios/Python/bootstrap.py
@@ -2,11 +2,8 @@
 bootstrap.py — Python startup script for embedded iOS backend.
 
 Called by PythonRunner.swift after CPython is initialized.
-Configures sys.path to include the bundled backend directory,
+Uses PYXUS_DATA_DIR (set by Swift) to locate the bundled backend,
 then starts uvicorn serving the FastAPI app.
-
-Phase 2: This will run inside the embedded CPython interpreter.
-For now it serves as documentation of the intended startup sequence.
 """
 
 import os
@@ -14,27 +11,25 @@ import sys
 
 
 def main():
-    # The backend/ directory is bundled as a resource in the app
-    bundle_dir = os.path.dirname(os.path.abspath(__file__))
-    backend_dir = os.path.join(bundle_dir, "..", "backend")
+    data_dir = os.environ.get("PYXUS_DATA_DIR")
+    if data_dir:
+        backend_dir = os.path.join(data_dir, "backend")
+    else:
+        bundle_dir = os.path.dirname(os.path.abspath(__file__))
+        backend_dir = os.path.join(bundle_dir, "..", "backend")
 
-    # Add backend to Python path so imports work (drone, mission, weather, etc.)
     if backend_dir not in sys.path:
         sys.path.insert(0, backend_dir)
 
-    # Set working directory to backend so relative paths (settings.json etc.) work
     os.chdir(backend_dir)
 
-    # Start uvicorn
     import uvicorn
     uvicorn.run(
         "main:app",
         host="127.0.0.1",
         port=8000,
         log_level="info",
-        # Single worker on mobile — no need for multiprocessing
         workers=1,
-        # Disable reload on mobile
         reload=False,
     )
 

--- a/ios/pyxios/pyxios/Python/python-bridge.h
+++ b/ios/pyxios/pyxios/Python/python-bridge.h
@@ -1,0 +1,18 @@
+//
+//  python-bridge.h
+//  pyxios
+//
+//  Bridging header that exposes CPython's C API to Swift.
+//  Add this file as the Objective-C Bridging Header in Xcode:
+//    Build Settings → Swift Compiler → Objective-C Bridging Header
+//
+//  Requires Python.xcframework from python-apple-support to be
+//  added to the Xcode project's Frameworks.
+//
+
+#ifndef python_bridge_h
+#define python_bridge_h
+
+#include <Python/Python.h>
+
+#endif /* python_bridge_h */

--- a/ios/scripts/bundle-python-deps.sh
+++ b/ios/scripts/bundle-python-deps.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# bundle-python-deps.sh
+#
+# Prepares pure-Python dependencies and Pyxus source files for
+# inclusion in the iOS app bundle. Run from the repo root:
+#
+#   ./ios/scripts/bundle-python-deps.sh
+#
+# Output structure (inside ios/pyxios/pyxios/Resources/):
+#   site-packages/   — pip-installed pure-Python packages
+#   backend/         — backend/*.py source files
+#   frontend-dist/   — pre-built frontend (from frontend/dist/)
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RESOURCES="$REPO_ROOT/ios/pyxios/pyxios/Resources"
+
+echo "==> Repo root: $REPO_ROOT"
+echo "==> Resources: $RESOURCES"
+
+# Clean previous output
+rm -rf "$RESOURCES/site-packages" "$RESOURCES/backend" "$RESOURCES/frontend-dist"
+mkdir -p "$RESOURCES/site-packages" "$RESOURCES/backend" "$RESOURCES/frontend-dist"
+
+# 1. Install pure-Python dependencies
+echo "==> Installing Python dependencies..."
+pip install \
+    --target "$RESOURCES/site-packages" \
+    --no-compile \
+    --no-deps \
+    fastapi uvicorn pydantic httpx pymavlink 2>&1 | tail -5
+
+echo "==> Removing .dist-info and __pycache__..."
+find "$RESOURCES/site-packages" -type d -name "*.dist-info" -exec rm -rf {} + 2>/dev/null || true
+find "$RESOURCES/site-packages" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+
+# 2. Copy backend source
+echo "==> Copying backend source..."
+cp "$REPO_ROOT"/backend/*.py "$RESOURCES/backend/"
+
+# 3. Copy frontend dist (must be pre-built)
+if [ -d "$REPO_ROOT/frontend/dist" ]; then
+    echo "==> Copying frontend dist..."
+    cp -R "$REPO_ROOT/frontend/dist/"* "$RESOURCES/frontend-dist/"
+else
+    echo "WARNING: frontend/dist not found — run 'cd frontend && npx vite build' first"
+fi
+
+echo "==> Done. Contents:"
+echo "    site-packages: $(find "$RESOURCES/site-packages" -name '*.py' | wc -l | tr -d ' ') .py files"
+echo "    backend:       $(ls "$RESOURCES/backend/"*.py 2>/dev/null | wc -l | tr -d ' ') .py files"
+echo "    frontend-dist: $(find "$RESOURCES/frontend-dist" -type f 2>/dev/null | wc -l | tr -d ' ') files"


### PR DESCRIPTION
## Summary
- Add `python-bridge.h` bridging header exposing CPython C API to Swift
- Rewrite `PythonRunner.swift` to initialize embedded CPython: sets `PYTHONHOME`, `PYTHONPATH`, `PYXUS_DATA_DIR`, `PYXUS_FRONTEND_DIR`, calls `Py_Initialize()`, executes `bootstrap.py` on background DispatchQueue, then polls `/health`
- Falls back to external backend polling when no bundled backend is detected (dev mode)
- Add `ios/scripts/bundle-python-deps.sh` that pip-installs pure-Python deps, copies backend source, and copies frontend dist to `Resources/`

## Test plan
- [x] Shell script syntax check passes
- [ ] Manual: Xcode project compiles after adding Python.xcframework and bridging header
- [ ] Manual: `bundle-python-deps.sh` runs without errors
- [ ] Manual: app launches and backend starts on simulator/device

🤖 Generated with [Claude Code](https://claude.com/claude-code)